### PR TITLE
Add set_state 

### DIFF
--- a/src/prog_client/session.py
+++ b/src/prog_client/session.py
@@ -4,6 +4,8 @@
 import requests, json
 import urllib3
 import pickle
+from prog_algs.uncertain_data import UncertainData
+import prog_models
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -87,6 +89,31 @@ class Session:
         """
         result = requests.post(self.host + '/loading', data={'type': type, 'cfg': json.dumps(cfg)})
         
+        # If error code throw Exception
+        if result.status_code != 204:
+            raise Exception(result.text)
+
+    def set_state(self, x):
+        """
+        Set the model state.
+
+        Args:
+            x (UncertainData, Dict, model.StateContainer): Model state
+        """
+        if isinstance(x, UncertainData):
+            x = pickle.dumps(x)
+            input_format = 'uncertain_data'
+        elif isinstance(x, prog_models.utils.containers.DictLikeMatrixWrapper):
+            x = pickle.dumps(x)
+            input_format = 'state_container'
+        elif isinstance(x, dict):
+            x = {'x': json.dumps(x)}
+            input_format = 'dict'
+        else:
+            raise Exception('Invalid state type ' + str(type(x)))
+
+        result = requests.post(self.host + '/state', data=x, params={'format': input_format})
+
         # If error code throw Exception
         if result.status_code != 204:
             raise Exception(result.text)

--- a/src/prog_server/controllers.py
+++ b/src/prog_server/controllers.py
@@ -124,11 +124,18 @@ def set_state(session_id):
     if session_id not in sessions:
         abort(400, f'Session {session_id} does not exist or has ended')
 
-    if 'x' not in request.form:
-        abort(400, "state ('x') must be specified in request body")
+    mode = request.args.get('format', 'dict')
 
-    app.logger.debug(f"Setting state for Session {session_id}")
-    x = request.form.get('x')
+    app.logger.debug(f"Setting state for Session {session_id}. Format: {mode}")
+
+    if mode == 'dict':
+        if 'x' not in request.form:
+            abort(400, "state ('x') must be specified in request body")
+        x = sessions[session_id].model.StateContainer(json.loads(request.form.get('x')))
+    elif mode == 'uncertain_data' or mode == 'state_container':
+        x = pickle.loads(request.get_data())
+    else:
+        abort(400, f'Unsupported format: {mode}')
     
     sessions[session_id].set_state(x)
 


### PR DESCRIPTION
With v1.3, prog_algs now supports an x0 of type UncertainData (e.g., MultivariateNormalDist). This update adds a set_state method and allows the user to send the state as type uncertaindata 