### PR TITLE
Add support for custom model

### DIFF
--- a/src/prog_client/session.py
+++ b/src/prog_client/session.py
@@ -32,7 +32,7 @@ class Session:
     """
 
     _base_url = '/api/v1'
-    def __init__(self, model, host = '127.0.0.1', port=5000, **kwargs):
+    def __init__(self, model, host = '127.0.0.1', port=8555, **kwargs):
         self.host = 'http://' + host + ':' + str(port) + Session._base_url
 
         # Process kwargs with json value

--- a/src/prog_server/__init__.py
+++ b/src/prog_server/__init__.py
@@ -2,6 +2,8 @@
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
 from .models.prog_server import server
+import time
+
 __version__ = '1.7.0-pre'
 
 def run(**kwargs):
@@ -15,22 +17,39 @@ def run(**kwargs):
     """
     server.run(**kwargs)
 
-def start(**kwargs):
+def start(timeout=10, **kwargs):
     """
     Start the server (not blocking).
 
     Args:
+        timeout (float, optional): Timeout in seconds for starting the service
+
+    Keyword Args:
         host (str, optional): Server host. Defaults to '127.0.0.1'.
         port (int, optional): Server port. Defaults to 5000.
         debug (bool, optional): If the server is started in debug mode
     """
     server.start(**kwargs)
+    for i in range(timeout):
+        if server.is_running():
+            return
+        time.sleep(1)
+    server.stop()
+    raise Exception("Server startup timeout")
 
-def stop():
+def stop(timeout=10):
     """
     Stop the server.
+
+    Args:
+        timeout (float, optional): Timeout in seconds for starting the service
     """
     server.stop()
+    for i in range(timeout):
+        if not server.is_running():
+            return
+        time.sleep(1)
+    raise Exception("Server startup timeout")
 
 def is_running():
     """

--- a/src/prog_server/models/prog_server.py
+++ b/src/prog_server/models/prog_server.py
@@ -1,10 +1,16 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
+from copy import deepcopy
 from prog_server.app import app
+from prog_server.models import session
 
 from multiprocessing import Process
 import requests
+from progpy import PrognosticsModel
+
+DEFAULT_PORT = 8555
+DEFAULT_HOST = '127.0.0.1'
 
 
 class ProgServer():
@@ -15,17 +21,25 @@ class ProgServer():
     def __init__(self):
         self.process = None
 
-    def run(self, host='127.0.0.1', port=5000, debug=False) -> None:
+    def run(self, host=DEFAULT_HOST, port=DEFAULT_PORT, debug=False, models={}, **kwargs) -> None:
         """Run the server (blocking)
 
-        Args:
+        Keyword Args:
             host (str, optional): Server host. Defaults to '127.0.0.1'.
-            port (int, optional): Server port. Defaults to 5000.
+            port (int, optional): Server port. Defaults to 18555.
             debug (bool, optional): If the server is started in debug mode
+            models (dict[str, PrognosticsModel]): a dictionary of extra models to consider. The key is the name used to identify it. 
         """
-        self.process = app.run(host = host, port = port, debug=debug)        
+        if not isinstance(models, dict):
+            raise TypeError("Extra models (`model` arg in prog_server.run() or start()) must be in a dictionary in the form `name: model_name`")
 
-    def start(self, **kwargs) -> None:
+        session.extra_models.update(models)
+
+        self.host = host
+        self.port = port
+        self.process = app.run(host=host, port=port, debug=debug)
+
+    def start(self, host=DEFAULT_HOST, port=DEFAULT_PORT, **kwargs) -> None:
         """Start the server in a separate process
         
         Args:
@@ -33,6 +47,11 @@ class ProgServer():
         """
         if self.process and self.process.is_alive():
             raise RuntimeError('Server already running')
+        self.host = host
+        self.port = port
+        kwargs['host'] = host
+        kwargs['port'] = port
+                    
         self.process = Process(target=self.run, kwargs=kwargs)
         self.process.start()
 
@@ -45,7 +64,7 @@ class ProgServer():
         if not self.process:
             return False
         if (isinstance(self.process, Process) and self.process.is_alive()) or not isinstance(self.process, Process):
-            url = "http://127.0.0.1:5000/api/v1/"
+            url = f"http://{self.host}:{self.port}/api/v1/"
             try:
                 requests.request("GET", url)
                 return True


### PR DESCRIPTION
A few changes that I'm having trouble separating:

* Updated default port (since 5000 is used by Airplay among other features)
* Added logic to block start() and stop() until server has started/stopped
* Fixed bug in has_started that causes it not to work when not using default port
* Added support for custom models (but only in initiated form)