### PR TITLE
Added feature to get current and predicted output

### DIFF
--- a/specs/swagger.yaml
+++ b/specs/swagger.yaml
@@ -104,7 +104,32 @@ paths:
               schema:
                 $ref: "#/components/schemas/StateReturnWithTime" 
         "400":
-          description: Session not active, or model not initialized 
+          description: Session not active, or model not initialized
+  /v1/session/{id}/output: 
+    parameters:
+      - name: id
+        description: id for the active session (generated when session began)
+        in: path 
+        required: true
+        schema:
+          type: integer
+      - name: return_format
+        description: Format for the returned state
+        in: query
+        required: false
+        schema:
+          $ref: "#/components/schemas/ReturnFormat"
+    get:
+      description: Get the most recent estimate of the system output for the model used in this session.
+      responses:
+        "200":
+          description: Okay response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StateReturnWithTime" 
+        "400":
+          description: Session not active, or model not initialized
   /v1/session/{id}/event_state:
     parameters:
       - name: id
@@ -128,7 +153,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StateReturnWithTime" 
         "400":
-          description: Session not active, or model not initialized 
+          description: Session not active, or model not initialized
   /v1/session/{id}/performance_metrics:
     parameters:
       - name: id
@@ -176,7 +201,31 @@ paths:
               schema:
                 $ref: "#/components/schemas/PredictionWithTime"
         "400":
-          description: Session not active, or model not initialized 
+          description: Session not active, or model not initialized
+  /v1/session/{id}/prediction/output:
+    parameters:
+      - name: id
+        in: path 
+        required: true
+        schema:
+          type: integer
+      - name: return_format
+        description: Format for the returned state
+        in: query
+        required: false
+        schema:
+          $ref: "#/components/schemas/ReturnFormat"
+    get:
+      description: Get the predicted output at save points (defined by pred_cfg['save_pts'] or pred_cfg['save_freq'])
+      responses:
+        "200":
+          description: Okay response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PredictionWithTime"
+        "400":
+          description: Session not active, or model not initialized
   /v1/session/{id}/prediction/event_state:
     parameters:
       - name: id

--- a/specs/swagger.yaml
+++ b/specs/swagger.yaml
@@ -102,7 +102,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StateReturnWithTime" 
+                $ref: "#/components/schemas/PredictionPointWithTime" 
         "400":
           description: Session not active, or model not initialized
   /v1/session/{id}/output: 
@@ -127,7 +127,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StateReturnWithTime" 
+                $ref: "#/components/schemas/PredictionPointWithTime" 
         "400":
           description: Session not active, or model not initialized
   /v1/session/{id}/event_state:
@@ -151,7 +151,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StateReturnWithTime" 
+                $ref: "#/components/schemas/PredictionPointWithTime" 
         "400":
           description: Session not active, or model not initialized
   /v1/session/{id}/performance_metrics:
@@ -175,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StateReturnWithTime"
+                $ref: "#/components/schemas/PredictionPointWithTime"
         "400":
           description: Session not active, or model not initialized 
   /v1/session/{id}/prediction/state:
@@ -382,9 +382,9 @@ components:
           type: object
           properties:
             schema:
-              $ref: "#/components/schemas/StateReturn"
+              $ref: "#/components/schemas/PredictionPoint"
 
-    StateReturnWithTime:
+    PredictionPointWithTime:
       type: object
       description: The requested property with the time it was calculated
       required:
@@ -397,19 +397,24 @@ components:
           type: object
           properties:
             schema:
-              $ref: "#/components/schemas/StateReturn"
+              $ref: "#/components/schemas/PredictionPoint"
         performance_metrics:
           type: object
           properties:
             schema:
-              $ref: "#/components/schemas/StateReturn"
+              $ref: "#/components/schemas/PredictionPoint"
         state:
           type: object
           properties:
             schema:
-              $ref: "#/components/schemas/StateReturn"
+              $ref: "#/components/schemas/PredictionPoint"
+        output:
+          type: object
+          properties:
+            schema:
+              $ref: "#/components/schemas/PredictionPoint"
            
-    StateReturn:
+    PredictionPoint:
       oneOf:
         - type: object
           description: JSON representing requested variable (e.g., state, event state, performance metric)
@@ -600,6 +605,11 @@ components:
           properties:
             schema:
               $ref: "#/components/schemas/Prediction"
+        outputs:
+          type: object
+          properties:
+            schema:
+              $ref: "#/components/schemas/Prediction"
         performance_metrics:
           type: object
           properties:
@@ -617,7 +627,7 @@ components:
             type: object
             properties:
               schema:
-                $ref: "#/components/schemas/StateReturn"
+                $ref: "#/components/schemas/PredictionPoint"
         
     PredictionStatus:
       type: object

--- a/src/prog_client/session.py
+++ b/src/prog_client/session.py
@@ -135,6 +135,23 @@ class Session:
         result = pickle.load(result.raw)
         return (result['time'], result['state'])
 
+    def get_output(self):
+        """Get the model output 
+
+        Returns:
+            tuple: \\
+                | float: Time of state estimate
+                | UncertainData: Model state
+        """
+        result = requests.get(self.host + '/output', params={'return_format': 'uncertain_data'}, stream='True')
+
+        # If error code throw Exception
+        if result.status_code != 200:
+            raise Exception(result.text)
+
+        result = pickle.load(result.raw)
+        return (result['time'], result['output'])
+
     def get_predicted_state(self):
         """Get the predicted model state 
 
@@ -168,6 +185,23 @@ class Session:
 
         result = pickle.load(result.raw)
         return (result['time'], result['event_state'])
+
+    def get_predicted_output(self):
+        """Get the predicted output
+
+        Returns:
+            tuple: \\
+                | float: Time of prediction
+                | Prediction: predicted Event state
+        """
+        result = requests.get(self.host + '/prediction/output', params={'return_format': 'uncertain_data'}, stream='True')
+
+        # If error code throw Exception
+        if result.status_code != 200:
+            raise Exception(result.text)
+
+        result = pickle.load(result.raw)
+        return (result['prediction_time'], result['outputs'])
 
     def get_predicted_event_state(self):
         """Get the predicted event state

--- a/src/prog_server/app.py
+++ b/src/prog_server/app.py
@@ -30,11 +30,13 @@ app.add_url_rule(PREFIX + '/session/<int:session_id>/model', methods=['GET'], vi
 
 # Get current state
 app.add_url_rule(PREFIX + '/session/<int:session_id>/state', methods=['GET'], view_func=get_state)
+app.add_url_rule(PREFIX + '/session/<int:session_id>/output', methods=['GET'], view_func=get_output)
 app.add_url_rule(PREFIX + '/session/<int:session_id>/event_state', methods=['GET'], view_func=get_event_state)
 app.add_url_rule(PREFIX + '/session/<int:session_id>/performance_metrics', methods=['GET'], view_func=get_perf_metrics)
 
 # Get Prediction
 app.add_url_rule(PREFIX + '/session/<int:session_id>/prediction/state', methods=['GET'], view_func=get_predicted_states)
+app.add_url_rule(PREFIX + '/session/<int:session_id>/prediction/output', methods=['GET'], view_func=get_predicted_output)
 app.add_url_rule(PREFIX + '/session/<int:session_id>/prediction/event_state', methods=['GET'], view_func=get_predicted_event_state)
 app.add_url_rule(PREFIX + '/session/<int:session_id>/prediction/performance_metrics', methods=['GET'], view_func=get_predicted_perf_metrics)
 app.add_url_rule(PREFIX + '/session/<int:session_id>/prediction/events', methods=['GET'], view_func=get_predicted_toe)


### PR DESCRIPTION
Added endpoints to get current and predicted outputs. Previously you had to use the model to calculate it from state. Changes include:

1. added endpoints for current and predicted outputs
2. Added functions to get it for the client
3. Added to the swagger file
4. Added test of endpoint functioning with client