### PR TITLE
Remove hardcoded dt parameter

### DIFF
--- a/src/prog_server/models/prediction_handler.py
+++ b/src/prog_server/models/prediction_handler.py
@@ -15,7 +15,7 @@ def predict(session):
             x = deepcopy(session.state_est.x)
             time = session.state_est.t
         
-        (_, _, states, outputs, event_states, events) = session.pred.predict(x, session.load_est, dt=0.1, t0=time)
+        (_, _, states, outputs, event_states, events) = session.pred.predict(x, session.load_est, t0=time)
 
     with session.locks['results']:
         session.results = (

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -146,6 +146,38 @@ class IntegrationTest(unittest.TestCase):
 
         # TODO UPDATED PREDICTION TIME
 
+    def test_dt(self):
+        # Set dt to 1 and save_freq to 0.1
+        session_point1 = prog_client.Session(
+            'ThrownObject',
+            pred_cfg={'save_freq': 0.1, 'dt':0.1})
+        session_1 = prog_client.Session(
+            'ThrownObject',
+            pred_cfg={'save_freq': 0.1, 'dt':1})
+
+        for _ in range(5):
+            # Wait for prediction to complete
+            time.sleep(0.5)
+            status = session_1.get_prediction_status()
+            if status['last prediction'] is not None:
+                break
+
+        for _ in range(5):
+            # Wait for prediction to complete
+            time.sleep(0.5)
+            status = session_point1.get_prediction_status()
+            if status['last prediction'] is not None:
+                break
+        
+        result_point1 = session_point1.get_predicted_event_state()
+        result_1 = session_1.get_predicted_event_state()
+        self.assertEqual(len(result_1[1][1].times), 9)
+        self.assertEqual(len(result_point1[1][1].times), 79)
+
+        # result_1 is less, despite having the same save_freq,
+        # because the time step is 1,
+        # so it can't save as frequently
+
     def test_error_in_init(self):
         # Invalid model name
         with self.assertRaises(Exception):


### PR DESCRIPTION
Removing this hardcoded parameter will allow clients to set dt as a session parameter. 

I tested it locally, but did not run unit / system tests. 